### PR TITLE
Fix noon to make hour a known value rather than an implied value

### DIFF
--- a/src/common/casualReferences.ts
+++ b/src/common/casualReferences.ts
@@ -137,7 +137,7 @@ export function afternoon(reference: ReferenceWithTimezone, implyHour = 15): Par
 export function noon(reference: ReferenceWithTimezone): ParsingComponents {
     const component = new ParsingComponents(reference, {});
     component.imply("meridiem", Meridiem.AM);
-    component.imply("hour", 12);
+    component.assign("hour", 12);
     component.imply("minute", 0);
     component.imply("second", 0);
     component.imply("millisecond", 0);


### PR DESCRIPTION
Making "noon" consistent with "midnight".

This is important to me because (for some unknown reason) 12 is by default implied for hour.  So I have code to check to see if hour is "implied" vs "known", and I throw it out if it's implied and set it to zero.  But for this "noon" I was throwing it out, which is not desired.

An alternative solution for me would be to allow a default hour to be set in config rather than implying 12.

Should the minute/second/milliseconds also be known for both midnight and noon?  Doesn't a